### PR TITLE
RDM Header range validation and dissector frame highlighting

### DIFF
--- a/src/dissectors/ASCII/asciiplugin.cpp
+++ b/src/dissectors/ASCII/asciiplugin.cpp
@@ -64,10 +64,17 @@ QVariant ASCIIPlugin::getDestination(const Packet &p)
     return QObject::tr("Broadcast");
 }
 
-QVariant ASCIIPlugin::getInfo(const Packet &p)
+QVariant ASCIIPlugin::getInfo(const Packet &p, int role)
 {
-    if (!p.size())
-        return tr("Invalid");
+    if (!p.size()) {
+        if (role == Qt::DisplayRole)
+            return tr("Invalid");
+        else if (role == Qt::BackgroundColorRole)
+            return Packet::Invalid::INVALID_PACKET_BACKGROUND;
+    }
+
+    if (role != Qt::DisplayRole)
+        return QVariant();
     switch (static_cast<quint8>(p.at(0)))
     {
         case E110_SC::ASCII_TEXT:

--- a/src/dissectors/ASCII/asciiplugin.h
+++ b/src/dissectors/ASCII/asciiplugin.h
@@ -37,7 +37,7 @@ public:
     QList<quint8> getStartCodes() override;
     QVariant getSource(const Packet &p) override;
     QVariant getDestination(const Packet &p) override;
-    QVariant getInfo(const Packet &p) override;
+    QVariant getInfo(const Packet &p, int role = Qt::DisplayRole) override;
     int preprocessPacket(const Packet &p, QList<Packet> &list) override;
     void dissectPacket(const Packet &p, QTreeWidgetItem *parent) override;
 

--- a/src/dissectors/DMX/dmxplugin.cpp
+++ b/src/dissectors/DMX/dmxplugin.cpp
@@ -67,7 +67,7 @@ int DmxPlugin::preprocessPacket(const Packet &p, QList<Packet> &list)
 
 void DmxPlugin::dissectPacket(const Packet &p, QTreeWidgetItem *parent)
 {
-    QTreeWidgetItem *i = new QTreeWidgetItem();
+    QTreeWidgetItem *i = nullptr;
 
     parent->setText(0, getProtocolName().toString());
     Util::setPacketByteHighlight(parent, 0, p.size());

--- a/src/dissectors/DMX/dmxplugin.cpp
+++ b/src/dissectors/DMX/dmxplugin.cpp
@@ -54,8 +54,11 @@ QVariant DmxPlugin::getDestination(const Packet &p)
     return QString("Broadcast");
 }
 
-QVariant DmxPlugin::getInfo(const Packet &p)
+QVariant DmxPlugin::getInfo(const Packet &p, int role)
 {
+    if (role != Qt::DisplayRole)
+        return QVariant();
+
     return QString("Slots %1").arg(p.size() - 1);
 }
 

--- a/src/dissectors/DMX/dmxplugin.h
+++ b/src/dissectors/DMX/dmxplugin.h
@@ -37,7 +37,7 @@ public:
     QList<quint8> getStartCodes() override;
     QVariant getSource(const Packet &p) override;
     QVariant getDestination(const Packet &p) override;
-    QVariant getInfo(const Packet &p) override;
+    QVariant getInfo(const Packet &p, int role = Qt::DisplayRole) override;
     int preprocessPacket(const Packet &p, QList<Packet> &list) override;
     void dissectPacket(const Packet &p, QTreeWidgetItem *parent) override;
 };

--- a/src/dissectors/RDM/rdmdissector.cpp
+++ b/src/dissectors/RDM/rdmdissector.cpp
@@ -802,8 +802,10 @@ void dissectMessageBlock(const Packet &p, QTreeWidgetItem *parent)
     Util::dissectGenericData(p, pidItem, RDM_MESSAGE_BLOCK + RDM_PARAMETER_DATA, pdl, genericDataType);
 }
 
-void dissectRdm(const Packet &p, QTreeWidgetItem *parent)
+dissectRdm_t dissectRdm(const Packet &p, QTreeWidgetItem *parent)
 {
+    dissectRdm_t frameStatus = FRAME_VALID;
+
 	// Within min/max RDM message size
 	if(p.size() < RDM_PACKET_MIN_BYTES)
 	{
@@ -812,7 +814,7 @@ void dissectRdm(const Packet &p, QTreeWidgetItem *parent)
 		i->setText(1, QString::number(p.size()));
         Util::setPacketByteHighlight(i, 0, p.size());
 		parent->addChild(i);
-		return;
+        return FRAME_INVALID;
 	}
 
 	if(p.size() > RDM_PACKET_MAX_BYTES)
@@ -822,7 +824,7 @@ void dissectRdm(const Packet &p, QTreeWidgetItem *parent)
 		i->setText(1, QString::number(p.size()));
         Util::setPacketByteHighlight(i, 0, RDM_PACKET_MAX_BYTES);
 		parent->addChild(i);
-		return;
+        return FRAME_INVALID;
 	}
 
 	// Sub Start Code
@@ -831,8 +833,10 @@ void dissectRdm(const Packet &p, QTreeWidgetItem *parent)
 	i->setText(0, "Sub-Start Code");
 	i->setText(1, QString::number(subStartCode));
     Util::setPacketByteHighlight(i, RDM_SUB_START_CODE, 1);
-    if (subStartCode != E120_SC_SUB_MESSAGE) // Valid value of SC_SUB_MESSAGE only
+    if (subStartCode != E120_SC_SUB_MESSAGE) { // Valid value of SC_SUB_MESSAGE only
         Util::setItemInvalid(i);
+        frameStatus = FRAME_INVALID;
+    }
     parent->addChild(i);
    
 	// Length and calculated checksum
@@ -850,6 +854,7 @@ void dissectRdm(const Packet &p, QTreeWidgetItem *parent)
 	else
 	{
         Util::setItemInvalid(i);
+        frameStatus = FRAME_INVALID;
 		i->setText(1, QString("Short: (%1) expected (%2)").arg(p.size()-2).arg(length));
 	}
 
@@ -895,8 +900,10 @@ void dissectRdm(const Packet &p, QTreeWidgetItem *parent)
 			i->setText(0, "Port");
 			i->setText(1, QString::number(port));
             Util::setPacketByteHighlight(i, RDM_PORT_ID, 1);
-            if (port < 0x01 || port > 0xFF) // Valid range of 0x01 - 0xFF
+            if (port < 0x01 || port > 0xFF) { // Valid range of 0x01 - 0xFF
                 Util::setItemInvalid(i);
+                frameStatus = FRAME_INVALID;
+            }
 			parent->addChild(i);
 		} break;
 		
@@ -919,6 +926,7 @@ void dissectRdm(const Packet &p, QTreeWidgetItem *parent)
                 break; // Valid
             default:
                 Util::setItemInvalid(i);
+                frameStatus = FRAME_INVALID;
             }
 			parent->addChild(i);
 		} break;
@@ -941,6 +949,7 @@ void dissectRdm(const Packet &p, QTreeWidgetItem *parent)
     if (subdevice < 0x0000 || subdevice > 0x0200) { // Valid range of 0x0000 - 0x0200
         if (!(cc == E120_SET_COMMAND && subdevice == E120_SUB_DEVICE_ALL_CALL)) { // SUB_DEVICE_ALL_CALL allowed for SET
             Util::setItemInvalid(i);
+            frameStatus = FRAME_INVALID;
         }
     }
 	parent->addChild(i);
@@ -994,17 +1003,22 @@ void dissectRdm(const Packet &p, QTreeWidgetItem *parent)
 	else
 	{
         Util::setItemInvalid(i);
+        frameStatus = FRAME_INVALID;
 		i->setText(1, QString("Invalid (%1 != %2)")
 			.arg(checksum, 4, 16, QChar('0'))
 			.arg(actualChecksum, 4, 16, QChar('0')));
 	}
     Util::setPacketByteHighlight(i, length, 2);
 	parent->addChild(i);
+
+    return frameStatus;
 }
 
 
-void dissectRdmDiscResponse(const Packet &p, QTreeWidgetItem *parent)
+dissectRdm_t dissectRdmDiscResponse(const Packet &p, QTreeWidgetItem *parent)
 {
+    dissectRdm_t frameStatus = FRAME_VALID;
+
 	int index=0;
 	while(p[index]==0xfe && index<p.length())
 		index++;
@@ -1020,7 +1034,7 @@ void dissectRdmDiscResponse(const Packet &p, QTreeWidgetItem *parent)
         i->setText(0, "Invalid Response - too short");
         Util::setPacketByteHighlight(i, index, p.length());
 		parent->addChild(i);
-		return;
+        return FRAME_INVALID;
 	}
 
 	quint8 preambleSep = p[index];
@@ -1038,7 +1052,7 @@ void dissectRdmDiscResponse(const Packet &p, QTreeWidgetItem *parent)
 	parent->addChild(i);
 	index++;
 	if(preambleSep!=0xAA)
-		return;
+        return FRAME_INVALID;
 
 	// EUID
 	i = new QTreeWidgetItem();
@@ -1091,8 +1105,11 @@ void dissectRdmDiscResponse(const Packet &p, QTreeWidgetItem *parent)
     {
         text.append(QString("Incorrect - should be %1").arg(localChecksum, 4, 16, QChar('0')));
         Util::setItemInvalid(i);
+        frameStatus = FRAME_INVALID;
     }
 	i->setText(1, text);
+
+    return frameStatus;
 }
 
 void dissectProductDetailIdListReply(const Packet &p, QTreeWidgetItem *parent, int offset, int pdl)

--- a/src/dissectors/RDM/rdmdissector.h
+++ b/src/dissectors/RDM/rdmdissector.h
@@ -62,9 +62,14 @@ enum RDM_PACKET_STRUCT
     RDM_PACKET_MAX_BYTES = 257
 };
 
-void dissectRdmDiscResponse(const Packet &p, QTreeWidgetItem *parent);
+typedef enum {
+    FRAME_VALID,
+    FRAME_INVALID
+} dissectRdm_t;
 
-void dissectRdm(const Packet &p, QTreeWidgetItem *parent);
+dissectRdm_t dissectRdmDiscResponse(const Packet &p, QTreeWidgetItem *parent);
+
+dissectRdm_t dissectRdm(const Packet &p, QTreeWidgetItem *parent);
 
 quint64 unpackRdmId(const Packet &p, int start);
 

--- a/src/dissectors/RDM/rdmplugin.cpp
+++ b/src/dissectors/RDM/rdmplugin.cpp
@@ -27,6 +27,8 @@
 
 #include "rdmdissector.h"
 
+const QColor RdmPlugin::DISCOVERY_COLLISION_BACKGROUND = QColor(204, 153, 0);
+
 
 QVariant RdmPlugin::getProtocolName()
 {
@@ -77,17 +79,17 @@ QVariant RdmPlugin::getDestination(const Packet &p)
     }
 }
 
-QVariant RdmPlugin::getInfo(const Packet &p)
+QVariant RdmPlugin::getInfo(const Packet &p, int role)
 {
     QString sInfo;
+    QVariant cInfo;
 
     if (p[0]==E110_SC::RDM)
     {
-        if(p.length() < RDM_MIN_BYTES)
+        if(p.length() < RDM_MIN_BYTES) {
             sInfo = "TOO SHORT: " + QString::number(p.length()) + " bytes";
-        else
-        {
-
+            cInfo = Packet::Invalid::INVALID_PACKET_BACKGROUND;
+        } else {
             switch(p[RDM_MESSAGE_BLOCK + RDM_CC])
             {
             case E120_DISCOVERY_COMMAND:
@@ -121,26 +123,40 @@ QVariant RdmPlugin::getInfo(const Packet &p)
                 quint64 upperBound = unpackRdmId(p, RDM_MESSAGE_BLOCK + RDM_PARAMETER_DATA + RDM_UID_LENGTH);
                 quint64 searchLength = 1+upperBound-lowerBound;
                 sInfo.append(QString(" from %1 to %2 (%3 address%4)")
-                             .arg(formatRdmUid(lowerBound, false))
-                             .arg(formatRdmUid(upperBound, false))
-                             .arg(QLocale().toString(searchLength))
-                             .arg(searchLength > 1 ? "es" : ""));
+                             .arg(
+                                 formatRdmUid(lowerBound, false),
+                                 formatRdmUid(upperBound, false),
+                                 QLocale().toString(searchLength),
+                                 searchLength > 1 ? "es" : ""));
 
             }
+
+            {
+                // Validate packet
+                QTreeWidgetItem dummyWidgetItem;
+                if (dissectRdm(p, &dummyWidgetItem) == FRAME_INVALID)
+                    cInfo = Packet::Invalid::INVALID_PACKET_BACKGROUND;
+            }
         }
+
     }
     else
     {
         // Discovery Response
-        sInfo = "DISCOVERY DISC_UNIQUE_BRANCH RESPONSE - ";
+        sInfo = "DISCOVERY DISC_UNIQUE_BRANCH RESPONSE";
         quint64 decodedId;
-        if(quickValidateDiscoveryResponse(p, decodedId))
-            sInfo.append("VALID");
-        else
-            sInfo.append("INVALID");
+        if(!quickValidateDiscoveryResponse(p, decodedId))
+            cInfo = DISCOVERY_COLLISION_BACKGROUND;
     }
 
-    return sInfo;
+    switch (role) {
+    case Qt::DisplayRole:
+        return sInfo;
+    case Qt::BackgroundRole:
+        return cInfo;
+    default:
+        return QVariant();
+    }
 }
 
 int RdmPlugin::preprocessPacket(const Packet &p, QList<Packet> &list)

--- a/src/dissectors/RDM/rdmplugin.cpp
+++ b/src/dissectors/RDM/rdmplugin.cpp
@@ -175,7 +175,7 @@ int RdmPlugin::preprocessPacket(const Packet &p, QList<Packet> &list)
 
 void RdmPlugin::dissectPacket(const Packet &p, QTreeWidgetItem *parent)
 {
-    QTreeWidgetItem *i = new QTreeWidgetItem();
+    QTreeWidgetItem *i = nullptr;
 
     parent->setText(0, getProtocolName().toString());
     Util::setPacketByteHighlight(parent, 0, p.size());

--- a/src/dissectors/RDM/rdmplugin.h
+++ b/src/dissectors/RDM/rdmplugin.h
@@ -37,12 +37,13 @@ public:
     QList<quint8> getStartCodes() override;
     QVariant getSource(const Packet &p) override;
     QVariant getDestination(const Packet &p) override;
-    QVariant getInfo(const Packet &p) override;
+    QVariant getInfo(const Packet &p, int role = Qt::DisplayRole) override;
     int preprocessPacket(const Packet &p, QList<Packet> &list) override;
     void dissectPacket(const Packet &p, QTreeWidgetItem *parent) override;
 
 private:
     bool quickValidateDiscoveryResponse(const Packet &p, quint64 &decoded_id);
+    static const QColor DISCOVERY_COLLISION_BACKGROUND;
 };
 
 #endif // DMX_H

--- a/src/dissectors/SIP/sipplugin.h
+++ b/src/dissectors/SIP/sipplugin.h
@@ -37,7 +37,7 @@ public:
     QList<quint8> getStartCodes() override;
     QVariant getSource(const Packet &p) override;
     QVariant getDestination(const Packet &p) override;
-    QVariant getInfo(const Packet &p) override;
+    QVariant getInfo(const Packet &p, int role = Qt::DisplayRole) override;
     int preprocessPacket(const Packet &p, QList<Packet> &list) override;
     void dissectPacket(const Packet &p, QTreeWidgetItem *parent) override;
 

--- a/src/dissectors/UTF8/utf8plugin.cpp
+++ b/src/dissectors/UTF8/utf8plugin.cpp
@@ -64,10 +64,17 @@ QVariant UTF8Plugin::getDestination(const Packet &p)
     return QObject::tr("Broadcast");
 }
 
-QVariant UTF8Plugin::getInfo(const Packet &p)
+QVariant UTF8Plugin::getInfo(const Packet &p, int role)
 {
-    if (!p.size())
-        return tr("Invalid");
+    if (!p.size()) {
+        if (role == Qt::DisplayRole)
+            return tr("Invalid");
+        else if (role == Qt::BackgroundColorRole)
+            return Packet::Invalid::INVALID_PACKET_BACKGROUND;
+    }
+
+    if (role != Qt::DisplayRole)
+        return QVariant();
     switch (static_cast<quint8>(p.at(0)))
     {
         case E110_SC::UTF8_TEXT:

--- a/src/dissectors/UTF8/utf8plugin.h
+++ b/src/dissectors/UTF8/utf8plugin.h
@@ -37,7 +37,7 @@ public:
     QList<quint8> getStartCodes() override;
     QVariant getSource(const Packet &p) override;
     QVariant getDestination(const Packet &p) override;
-    QVariant getInfo(const Packet &p) override;
+    QVariant getInfo(const Packet &p, int role = Qt::DisplayRole) override;
     int preprocessPacket(const Packet &p, QList<Packet> &list) override;
     void dissectPacket(const Packet &p, QTreeWidgetItem *parent) override;
 

--- a/src/dissectors/dissectorplugin.h
+++ b/src/dissectors/dissectorplugin.h
@@ -61,7 +61,7 @@ public:
     /*
      * @return Get packet info
      */
-    virtual QVariant getInfo(const Packet &p) = 0;
+    virtual QVariant getInfo(const Packet &p, int role = Qt::DisplayRole) = 0;
 
     /*
      * Process packet and add to list

--- a/src/packetbuffer.cpp
+++ b/src/packetbuffer.cpp
@@ -26,28 +26,24 @@ const QColor Packet::Invalid::INVALID_PARAMETER_BACKGROUND = QColor(255, 80, 80)
 Packet::Packet()
     : QByteArray()
     , timestamp(0)
-    , isRdmCollision(false)
 {
 }
 
 Packet::Packet(const char* data, int size)
     : QByteArray(data, size)
     , timestamp(0)
-    , isRdmCollision(false)
 {
 }
 
 Packet::Packet(const QByteArray &data)
     : QByteArray(data)
     , timestamp(0)
-    , isRdmCollision(false)
 {
 }
 
 Packet::Packet(const Packet &other, int start)
     : QByteArray()
     , timestamp(other.timestamp)
-    , isRdmCollision(other.isRdmCollision)
 {
     append(other.mid(start));
 }

--- a/src/packetbuffer.cpp
+++ b/src/packetbuffer.cpp
@@ -20,6 +20,9 @@
 
 #include <packetbuffer.h>
 
+const QColor Packet::Invalid::INVALID_PACKET_BACKGROUND = QColor(255, 80, 80);
+const QColor Packet::Invalid::INVALID_PARAMETER_BACKGROUND = QColor(255, 80, 80);
+
 Packet::Packet()
     : QByteArray()
     , timestamp(0)

--- a/src/packetbuffer.h
+++ b/src/packetbuffer.h
@@ -22,6 +22,7 @@
 
 #include <QObject>
 #include <exception>
+#include <QColor>
 
 struct PacketAccessException : public std::exception {
    const char * what () const throw () {
@@ -39,6 +40,12 @@ public:
     Packet(const Packet &other, int start = 0);
 
     qint64 timestamp;
-    bool isRdmCollision;
     unsigned char operator[] ( int i ) const;
+
+    class Invalid
+    {
+    public:
+       static const QColor INVALID_PACKET_BACKGROUND;
+       static const QColor INVALID_PARAMETER_BACKGROUND;
+    };
 };

--- a/src/packettable.cpp
+++ b/src/packettable.cpp
@@ -105,7 +105,7 @@ QVariant PacketTable::data(const QModelIndex &index, int role) const
             if (role == Qt::DisplayRole) return dissector->getProtocolName();
             break;
         case Info       :
-            if (role == Qt::DisplayRole) return dissector->getInfo(m_packets.at(row));
+            return dissector->getInfo(m_packets.at(row), role);
             break;
         default:;
         }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -26,11 +26,9 @@
 #include <QTreeWidgetItem>
 #include <cmath>
 
-static QBrush BACKGROUND_INVALID(QColor(255, 80, 80));
-
 void Util::setItemInvalid(QTreeWidgetItem *item)
 {
-    item->setData(0, Qt::BackgroundRole, BACKGROUND_INVALID);
+    item->setData(0, Qt::BackgroundRole, Packet::Invalid::INVALID_PARAMETER_BACKGROUND);
 }
 
 void Util::setPacketByteHighlight(QTreeWidgetItem *item, int start, int length)


### PR DESCRIPTION
Adds range validation for the RDM header (Resolves #27)
Allows dissectors to apply formating to the packet table info column - For invalid packet highlighting
RDM Discovery collison highilghting

