### PR TITLE
Show manufacturer-specific PID in Info

### DIFF
--- a/src/rdm/rdmpidstrings.cpp
+++ b/src/rdm/rdmpidstrings.cpp
@@ -460,7 +460,8 @@ QString RDM_PIDString::dataTypeToString(quint8 dataType)
         default :
                 if ((dataType > 0x7F) && (dataType < 0xE0))
                 {
-                        return QString("Manufacturer-Specific");
+                  return QStringLiteral("Manufacturer-Specific: 0x%1 / %2")
+                      .arg(QString::number(dataType, 16).toUpper(), QString::number(dataType, 10));
                 }
         }
         return QString("INVALID");

--- a/src/util.h
+++ b/src/util.h
@@ -46,17 +46,22 @@ public:
 
     enum GenericParamDataTypeFlags
     {
-        GenericDataNumber   = 0x01,
-        GenericDataText     = 0x02,
-        GenericDataBitset   = 0x04,
-        GenericDataBool     = 0x08
+      GenericDataUnsigned     = 1 << 0,  // Unsigned integer
+      GenericDataUnsignedHex  = 1 << 1,  // Unsigned integer as hex
+      GenericDataSigned       = 1 << 2,  // Signed integer
+      GenericDataText         = 1 << 3,
+      GenericDataBitset       = 1 << 4,
+      GenericDataBool         = 1 << 5,
+
+      GenericDataUnsignedNumber = GenericDataUnsigned | GenericDataUnsignedHex,
+      GenericDataNumber = GenericDataUnsigned | GenericDataUnsignedHex | GenericDataSigned,
     };
 
     static void dissectGenericData(const Packet &p, QTreeWidgetItem *parent, int offset, int pdLength, quint8 dataTypeFlags = GenericDataNumber | GenericDataText | GenericDataBitset);
 
     static QString formatRdmUid(quint16 manufacturer, quint32 devId);
     static QString formatRdmUid(quint64 combinedId);
-    static QString paramIdToString(quint16 paramId);
+    static QString paramIdToString(quint16 paramId, bool *manufacturerSpecific = nullptr);
 
     static QString sensorUnitToString(quint8 unit);
     static QString sensorUnitToShortString(quint8 unit);


### PR DESCRIPTION
It's useful to see the manufacturer-specific PID number in the Info so it can be used to filter all traffic related to the PID

Also some optimizations and minor cleanup