### PR TITLE
Lib gadget fixes

### DIFF
--- a/Application.pro
+++ b/Application.pro
@@ -39,10 +39,6 @@ win32 {
     QMAKE_LFLAGS += /INCREMENTAL:NO /Debug
 }
 
-# Hardware includes
-include($$PWD/Whip.pri)
-include($$PWD/Gadget.pri)
-
 # Source
 INCLUDEPATH *= $$PWD/src
 
@@ -118,6 +114,10 @@ CONFIG(release, debug|release) {
 TARGET_CUSTOM_EXT = .exe
 DEPLOY_DIR = $$shell_quote($$system_path($${_PRO_FILE_PWD_}/install/deploy))
 DEPLOY_TARGET = $$shell_quote($$system_path($${DESTDIR}/$${TARGET}$${TARGET_CUSTOM_EXT}))
+
+# Hardware includes
+include($$PWD/Whip.pri)
+include($$PWD/Gadget.pri)
 
 # Configure Release deployment
 CONFIG(release, debug|release) {

--- a/Gadget.pri
+++ b/Gadget.pri
@@ -1,16 +1,15 @@
 # Gadget II
-INCLUDEPATH *= $$clean_path($$PWD/gadget/include)
-HEADERS += $$PWD/gadget/include/gadget/GadgetDLL.h
-
 win32 {
 contains(QT_ARCH, i386) {
         GADGET_DLL_SRC = $$shell_quote($$system_path($${_PRO_FILE_PWD_}/gadget/libGadget/Win32/bin/GadgetDLL.dll))
         LIBS += -L$$PWD/gadget/libGadget/Win32/lib -lGadgetDll
         INCLUDEPATH += $$PWD/gadget/libGadget/Win32/include
+        HEADERS += $$PWD/gadget/libGadget/Win32/include/GadgetDLL.h
     } else {
         GADGET_DLL_SRC = $$shell_quote($$system_path($${_PRO_FILE_PWD_}/gadget/libGadget/x64/bin/GadgetDLL.dll))
         LIBS += -L$$PWD/gadget/libGadget/x64/lib -lGadgetDll
         INCLUDEPATH += $$PWD/gadget/libGadget/x64/include
+        HEADERS += $$PWD/gadget/libGadget/x64/include/GadgetDLL.h
     }
     GADGET_DLL_DST = $$shell_quote($$system_path($${_PRO_FILE_PWD_}/install/deploy/GadgetDll.dll))
 } else {


### PR DESCRIPTION
When libGadget was imported as a submodule in a2ad96c9669d24918fbc44bbd324d574ebf315b0 the headers didn't get updated
This reinstates the headers.

Also allows Application.pro to be opened independently from EtcDmxTool.pro as it fixes the point at which the hardware includes get added, as these depend on DESTDIR being set.