### PR TITLE
#37 dissectors don't load

### DIFF
--- a/install/install.nsi
+++ b/install/install.nsi
@@ -137,6 +137,7 @@ Section "Main Application" sec01
 	
 	;Shortcuts
 	CreateDirectory '$SMPROGRAMS\${PRODUCT_NAME}'
+	SetOutPath '$INSTDIR' ;Used by CreateShortcut as the "Start In" path
 	CreateShortcut '$SMPROGRAMS\${PRODUCT_NAME}\${PRODUCT_NAME}.lnk' '$INSTDIR\${PRODUCT_NAME}.exe'
 	;create shortcut for uninstaller always use ${UNINST_EXE} instead of uninstall.exe
 	CreateShortcut '$SMPROGRAMS\${PRODUCT_NAME}\uninstall.lnk' '${UNINST_EXE}'

--- a/src/dissectors.h
+++ b/src/dissectors.h
@@ -25,6 +25,7 @@
 #include <QTreeWidget>
 #include <QList>
 #include <QLibrary>
+#include <QDir>
 #include "packetbuffer.h"
 #include "dissectors/dissectorplugin.h"
 
@@ -60,6 +61,8 @@ signals:
 public slots:
 
 private:
+    void load(QDir sourcePath);
+
     QList<s_DissectorList*> m_dissectors;
 
 #if defined (Q_OS_WIN)


### PR DESCRIPTION
Correctly set the "start in" path for the shortcuts created by the Windows installer.
Load dissectors from both the "start in" path (legacy behavior) as well as the application binary directory.

Resolves #37

Also fixes two clang warnings related to foreach and muliarg